### PR TITLE
Added Footer to the Bottom

### DIFF
--- a/playgrounds/app/src/app.css
+++ b/playgrounds/app/src/app.css
@@ -139,3 +139,12 @@
 ::-webkit-scrollbar-corner {
   display: none;
 }
+
+
+/* Full App Height and Letting Footer in the End */
+#app {
+  @apply min-h-screen flex flex-col ;
+}
+#app main { 
+  @apply w-full flex-1; 
+}


### PR DESCRIPTION
It makes the main app height grow and keep footer in the end, so when you have enough height you can see the step 2 animations with changing height without moving the footer so it only animates the image itself :)