### PR TITLE
Large Screens Container Fixes

### DIFF
--- a/playgrounds/app/src/app.css
+++ b/playgrounds/app/src/app.css
@@ -141,10 +141,13 @@
 }
 
 
-/* Full App Height and Letting Footer in the End */
+/* 
+  Full App Height and Letting Footer in the End
+  Max Width to the Main Container for Larger Screen Sizes
+*/
 #app {
-  @apply min-h-screen flex flex-col ;
+  @apply min-h-screen flex flex-col;
 }
 #app main { 
-  @apply w-full flex-1; 
+  @apply w-full flex-1 max-w-screen-2xl mx-auto; 
 }


### PR DESCRIPTION
So i've added a max-width to the main container, I use very large resolutions and the width had no limit which is too much for the readability, it's the same issue while tailwind has max-w-prose in the prose  because there's a limit text is readable at an horizontal level and also fluid layouts can suffer from extreme widths regarding with text distribution.

Before: 
<img width="2456" alt="before" src="https://github.com/user-attachments/assets/507bad9f-314d-4a1a-82f0-44757c3fd9a8">

After:
<img width="2442" alt="after" src="https://github.com/user-attachments/assets/612fb32e-c9c9-4533-aa6d-ea54c9159139">

I've used the default Tailwind cases to max-w-screen-2xl  of 1536px, maybe could be even set to max-w-screen because I believe anything larger than 1200px starts to open too much. 