### PR TITLE
Fix: smooth 30 fps output

### DIFF
--- a/playgrounds/app/src/components/Editor.tsx
+++ b/playgrounds/app/src/components/Editor.tsx
@@ -53,7 +53,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from './ui/accordion'
 
 const animationSeconds = 1
-const animationFPS = 10
+const animationFPS = 30
 const animationFrames = animationSeconds * animationFPS
 
 const supportedFontFamilies: { name: string }[] = [
@@ -208,7 +208,7 @@ export default function Editor(props: EditorProps) {
         middleFrames.push(i)
       }
 
-      const pauseFrameLength = 15
+      const pauseFrameLength = 60
       const firstFrames = new Array(pauseFrameLength).fill(0)
       const lastFrames = new Array(pauseFrameLength).fill(animationFrames)
 
@@ -260,7 +260,7 @@ export default function Editor(props: EditorProps) {
         format: 'blob',
         width: canvasFrames[0].width,
         height: canvasFrames[0].height,
-        frames: canvasFrames,
+        frames: canvasFrames.map(el => ({ data: el.data.buffer, delay: (animationSeconds * 1000) / animationFPS}))
       })
 
       const dataUrl = await blobToDataURL(blob)


### PR DESCRIPTION
Fixed frames delay in gif generation. The ideal duration of each frame is `(animationSeconds * 1000) / animationFPS`. Also need `BufferSource` instead of `ImageData` to be able to set the delay param.

Before:
![giffium-before](https://github.com/user-attachments/assets/011dfd2c-ba91-43d0-af63-3262c83150da)

After:
![giffium-after](https://github.com/user-attachments/assets/2ac282a7-30e2-4473-a674-f10d14fb4cb1)
